### PR TITLE
Fix AWS Bedrock response handling

### DIFF
--- a/model/amazon_bedrock.go
+++ b/model/amazon_bedrock.go
@@ -132,9 +132,8 @@ func (p *AmazonBedrockModelProvider) QueryText(question string, writer io.Writer
 		}
 		if maxTokens > modelResult.TotalTokenCount {
 			return modelResult, nil
-		} else {
-			return nil, fmt.Errorf("exceed max tokens")
 		}
+		return nil, fmt.Errorf("exceed max tokens")
 	}
 
 	resp, err := client.InvokeModel(context.TODO(), &bedrockruntime.InvokeModelInput{
@@ -145,11 +144,16 @@ func (p *AmazonBedrockModelProvider) QueryText(question string, writer io.Writer
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	var result struct {
 		Generation string `json:"generation"`
 	}
-	if err := json.Unmarshal(resp.Body, &result); err != nil {
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(bodyBytes, &result); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary
- fix unmarshal for Amazon Bedrock provider by reading response body first
- simplify dry run condition logic

## Testing
- `go vet model/amazon_bedrock.go` *(fails: Get ... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6847768f66908327b6730bc422878ee2