### PR TITLE
Add external tag links

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ Casibase contains 2 parts:
 
 <https://casibase.org/docs/basic/server-installation>
 
+## Tag Links
+
+Tags inside Casibase can link to external resources such as GitHub issues or community forum threads. Use tags to quickly navigate to related learning materials.
+
 ## How to contact?
 
 Discord: <https://discord.gg/5rPsrAzK7S>

--- a/controllers/tag_link.go
+++ b/controllers/tag_link.go
@@ -1,0 +1,70 @@
+package controllers
+
+import (
+	"encoding/json"
+
+	"github.com/beego/beego/utils/pagination"
+	"github.com/casibase/casibase/object"
+	"github.com/casibase/casibase/util"
+)
+
+// GetTagLinks
+// @Title GetTagLinks
+// @Tag TagLink API
+// @Description get tag links
+// @Success 200 {array} object.TagLink The Response object
+// @router /get-tag-links [get]
+func (c *ApiController) GetTagLinks() {
+	owner := c.Input().Get("owner")
+	tag := c.Input().Get("tag")
+	limit := c.Input().Get("pageSize")
+	page := c.Input().Get("p")
+
+	if limit == "" || page == "" {
+		links, err := object.GetTagLinks(owner, tag)
+		if err != nil {
+			c.ResponseError(err.Error())
+			return
+		}
+
+		c.ResponseOk(links)
+	} else {
+		limitInt := util.ParseInt(limit)
+		count, err := object.GetTagLinkCount(owner, tag)
+		if err != nil {
+			c.ResponseError(err.Error())
+			return
+		}
+		paginator := pagination.SetPaginator(c.Ctx, limitInt, count)
+		links, err := object.GetPaginationTagLinks(owner, paginator.Offset(), limitInt, tag)
+		if err != nil {
+			c.ResponseError(err.Error())
+			return
+		}
+		c.ResponseOk(links, paginator.Nums())
+	}
+}
+
+// AddTagLink
+// @Title AddTagLink
+// @Tag TagLink API
+// @Description add tag link
+// @Param body body object.TagLink true "The details of the tag link"
+// @Success 200 {object} controllers.Response The Response object
+// @router /add-tag-link [post]
+func (c *ApiController) AddTagLink() {
+	var link object.TagLink
+	err := json.Unmarshal(c.Ctx.Input.RequestBody, &link)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	success, err := object.AddTagLink(&link)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	c.ResponseOk(success)
+}

--- a/object/adapter.go
+++ b/object/adapter.go
@@ -254,4 +254,9 @@ func (a *Adapter) createTable() {
 	if err != nil {
 		panic(err)
 	}
+
+	err = a.engine.Sync2(new(TagLink))
+	if err != nil {
+		panic(err)
+	}
 }

--- a/object/tag_link.go
+++ b/object/tag_link.go
@@ -1,0 +1,118 @@
+package object
+
+import (
+	"fmt"
+
+	"github.com/casibase/casibase/util"
+	"xorm.io/core"
+)
+
+// TagLink connects a Casibase tag with an external resource
+// such as a GitHub issue, bookmark or forum thread.
+type TagLink struct {
+	Owner       string `xorm:"varchar(100) notnull pk" json:"owner"`
+	Name        string `xorm:"varchar(100) notnull pk" json:"name"`
+	CreatedTime string `xorm:"varchar(100)" json:"createdTime"`
+
+	Tag         string `xorm:"varchar(100) index" json:"tag"`
+	Type        string `xorm:"varchar(100)" json:"type"`
+	Url         string `xorm:"varchar(500)" json:"url"`
+	Description string `xorm:"varchar(500)" json:"description"`
+}
+
+func GetTagLinks(owner, tag string) ([]*TagLink, error) {
+	links := []*TagLink{}
+	session := adapter.engine.Desc("created_time")
+	if owner != "" {
+		session = session.Where("owner = ?", owner)
+	}
+	if tag != "" {
+		session = session.And("tag = ?", tag)
+	}
+	err := session.Find(&links)
+	if err != nil {
+		return links, err
+	}
+	return links, nil
+}
+
+func GetPaginationTagLinks(owner string, offset, limit int, tag string) ([]*TagLink, error) {
+	links := []*TagLink{}
+	session := adapter.engine.Desc("created_time")
+	if owner != "" {
+		session = session.Where("owner = ?", owner)
+	}
+	if tag != "" {
+		session = session.And("tag = ?", tag)
+	}
+	err := session.Limit(limit, offset).Find(&links)
+	if err != nil {
+		return links, err
+	}
+	return links, nil
+}
+
+func getTagLink(owner, name string) (*TagLink, error) {
+	if owner == "" || name == "" {
+		return nil, nil
+	}
+
+	link := TagLink{Owner: owner, Name: name}
+	existed, err := adapter.engine.Get(&link)
+	if err != nil {
+		return &link, err
+	}
+
+	if existed {
+		return &link, nil
+	} else {
+		return nil, nil
+	}
+}
+
+func GetTagLink(id string) (*TagLink, error) {
+	owner, name := util.GetOwnerAndNameFromId(id)
+	return getTagLink(owner, name)
+}
+
+func GetTagLinkCount(owner, tag string) (int64, error) {
+	session := adapter.engine.Where("1=1")
+	if owner != "" {
+		session = session.And("owner = ?", owner)
+	}
+	if tag != "" {
+		session = session.And("tag = ?", tag)
+	}
+	return session.Count(&TagLink{})
+}
+
+func UpdateTagLink(id string, link *TagLink) (bool, error) {
+	owner, name := util.GetOwnerAndNameFromId(id)
+	_, err := adapter.engine.ID(core.PK{owner, name}).AllCols().Update(link)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func AddTagLink(link *TagLink) (bool, error) {
+	affected, err := adapter.engine.Insert(link)
+	if err != nil {
+		return false, err
+	}
+
+	return affected != 0, nil
+}
+
+func DeleteTagLink(link *TagLink) (bool, error) {
+	affected, err := adapter.engine.ID(core.PK{link.Owner, link.Name}).Delete(&TagLink{})
+	if err != nil {
+		return false, err
+	}
+
+	return affected != 0, nil
+}
+
+func (link *TagLink) GetId() string {
+	return fmt.Sprintf("%s/%s", link.Owner, link.Name)
+}

--- a/routers/router.go
+++ b/routers/router.go
@@ -143,6 +143,9 @@ func initAPI() {
 	beego.Router("/api/add-node", &controllers.ApiController{}, "POST:AddNode")
 	beego.Router("/api/delete-node", &controllers.ApiController{}, "POST:DeleteNode")
 
+	beego.Router("/api/get-tag-links", &controllers.ApiController{}, "GET:GetTagLinks")
+	beego.Router("/api/add-tag-link", &controllers.ApiController{}, "POST:AddTagLink")
+
 	beego.Router("/api/get-machines", &controllers.ApiController{}, "GET:GetMachines")
 	beego.Router("/api/get-machine", &controllers.ApiController{}, "GET:GetMachine")
 	beego.Router("/api/update-machine", &controllers.ApiController{}, "POST:UpdateMachine")


### PR DESCRIPTION
## Summary
- allow linking tags to external learning resources
- expose API endpoints to manage tag links
- sync `TagLink` table in the database
- document the new tag link capability

## Testing
- `go test ./...` *(fails: Forbidden module downloads)*

------
https://chatgpt.com/codex/tasks/task_b_684784b43b3c832795fdb4ef9affbbca