### PR TITLE
Improve controller error handling

### DIFF
--- a/controllers/permission.go
+++ b/controllers/permission.go
@@ -68,7 +68,8 @@ func (c *ApiController) UpdatePermission() {
 	var permission casdoorsdk.Permission
 	err := json.Unmarshal(c.Ctx.Input.RequestBody, &permission)
 	if err != nil {
-		panic(err)
+		c.ResponseError(err.Error())
+		return
 	}
 
 	success, err := casdoorsdk.UpdatePermission(&permission)

--- a/controllers/tunnel.go
+++ b/controllers/tunnel.go
@@ -246,7 +246,8 @@ func (c *ApiController) TunnelMonitor() {
 	tunnel, err := guacamole.NewTunnel(addr, configuration)
 	if err != nil {
 		guacamole.Disconnect(ws, NewTunnelError, err.Error())
-		panic(err)
+		logs.Error(fmt.Sprintf("NewTunnel error: %v", err))
+		return
 	}
 
 	guacSession := &guacamole.Session{

--- a/controllers/util.go
+++ b/controllers/util.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/beego/beego/context"
+	"github.com/beego/beego/logs"
 	"github.com/casdoor/casdoor-go-sdk/casdoorsdk"
 	"github.com/casibase/casibase/conf"
 	"github.com/casibase/casibase/util"
@@ -146,7 +147,7 @@ func responseError(ctx *context.Context, error string, data ...interface{}) {
 
 	err := ctx.Output.JSON(resp, true, false)
 	if err != nil {
-		panic(err)
+		logs.Error(fmt.Sprintf("responseError JSON output failed: %v", err))
 	}
 }
 

--- a/controllers/video.go
+++ b/controllers/video.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/beego/beego"
+	"github.com/beego/beego/logs"
 	"github.com/beego/beego/utils/pagination"
 	"github.com/casibase/casibase/audio"
 	"github.com/casibase/casibase/object"
@@ -239,13 +240,14 @@ func updateVideoCoverUrl(id string, videoId string) error {
 func startCoverUrlJob(id string, videoId string) {
 	err := object.SetDefaultVodClient()
 	if err != nil {
-		panic(err)
+		logs.Error(fmt.Sprintf("SetDefaultVodClient error: %v", err))
+		return
 	}
 
 	go func(id string, videoId string) {
 		err = updateVideoCoverUrl(id, videoId)
 		if err != nil {
-			panic(err)
+			logs.Error(fmt.Sprintf("updateVideoCoverUrl error: %v", err))
 		}
 	}(id, videoId)
 }


### PR DESCRIPTION
## Summary
- avoid panics by returning initialization errors from account controller
- handle JSON errors in permission controller
- log JSON failures in response helpers
- log tunnel and video job initialization errors instead of panicking

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6847928483a08327878d8ce4f41e3ecb